### PR TITLE
Bugfixes & adjustment to General-Insurance for publishing DBB outputs

### DIFF
--- a/PublishLoadModules/ArtifactoryHelpers.groovy
+++ b/PublishLoadModules/ArtifactoryHelpers.groovy
@@ -41,7 +41,7 @@ def publish(serverUrl, repo, apiKey, remoteFilePath, File localFile) {
     def url = serverUrl.endsWith('/') ? serverUrl : serverUrl + '/'
 
     //Create SHA1 and MD5 checksums to be published along with the file
-    def sha1 = getChecksum(localFile)
+    def sha1 = getChecksum(localFile, "SHA1")
     def md5 = getChecksum(localFile, "MD5")
 
     def filePath = "$repo/$remoteFilePath"
@@ -85,8 +85,8 @@ def download(serverUrl, repo, apiKey, remoteFilePath, File localFile)
     //the transfer is complete
     def expectedSha1 = response.headers['X-Checksum-Sha1'].value
     def expectedMd5 = response.headers['X-Checksum-Md5'].value    
-    def actualSha1 = getChecksum(localFile)
-    def actualMd5 = getChecksum(localFile, "MD5")    
+    def actualSha1 = getChecksum(localFile, "SHA1")
+    def actualMd5 = getChecksum(localFile, "MD5")
     assert actualSha1 == expectedSha1 && actualMd5 == expectedMd5, "The downloaded file $localFile does not have the right checksum"
     
     println "Successfully download $filePath to $localFile"
@@ -127,7 +127,11 @@ def getChecksum(File file, type = 'SHA1')
     
     def digest = MessageDigest.getInstance(type)
     digest.update(file.bytes)
-    return new BigInteger(1,digest.digest()).toString(16)
+    switch (type) {
+    case "SHA1": return new BigInteger(1,digest.digest()).toString(16).padLeft(40, '0'); break
+    case "MD5": return new BigInteger(1,digest.digest()).toString(16).padLeft(32, '0'); break
+    default: println "Unsupported type"
+    }
 }
 
 def static encodeZipFile(Object data) throws UnsupportedEncodingException

--- a/PublishLoadModules/ArtifactoryHelpers.groovy
+++ b/PublishLoadModules/ArtifactoryHelpers.groovy
@@ -29,31 +29,30 @@ import groovyx.net.http.*
 /**
  * Publish a file from HFS to an artifactory repository at location specified in remoteFilePath
  */
-def publish(serverUrl, repo, apiKey, remoteFilePath, File localFile)
-{
+def publish(serverUrl, repo, apiKey, remoteFilePath, File localFile) {
     //Validate to make sure all required fields are specified
     assert serverUrl != null, "Need to specify a valid URL to artifactory server"
     assert repo != null, "Need to specify a valid artifactory repository"
     assert apiKey != null, "Need to specify a valid API key to authenticate with $repo"
     assert remoteFilePath != null, "Need to specify the path of the source file"
     assert localFile != null && localFile.exists(), "Target local file must exist"
-    
+
     //Artifactory URL must end with '/'
     def url = serverUrl.endsWith('/') ? serverUrl : serverUrl + '/'
 
     //Create SHA1 and MD5 checksums to be published along with the file
     def sha1 = getChecksum(localFile)
     def md5 = getChecksum(localFile, "MD5")
-       
-    def filePath = "$repo/$remoteFilePath" 
-    
+
+    def filePath = "$repo/$remoteFilePath"
+
     def restClient = new RESTClient(url)
     restClient.encoder.'application/zip' = this.&encodeZipFile
     def response = restClient.put(path: filePath, headers: ['X-JFrog-Art-Api' : apiKey, 'X-Checksum-Sha1' : sha1, 'X-Checksum-MD5' : md5], body: localFile, requestContentType: 'application/zip')
-    
+
     assert response.isSuccess(), "Failed to publish file $localFile"
-    
-    println "Successfully publish file $localFile to $filePath"
+
+    println "Successfully published file $localFile to $filePath"
 }
 
 /**
@@ -137,3 +136,4 @@ def static encodeZipFile(Object data) throws UnsupportedEncodingException
     entity.setContentType('application/zip');
     return entity
 }
+

--- a/PublishLoadModules/PublishLoadModule.groovy
+++ b/PublishLoadModules/PublishLoadModule.groovy
@@ -113,7 +113,8 @@ def startTime = sdf.format(date) as String
 // label as the name for the tar file
 def buildLabel = "build.$startTime"
 def tarFile = new File("$tempLoadDir/${buildLabel}.tar")
-def tarOut = ["sh", "-c", "cd $tempLoadDir && tar cf $tarFile *"].execute().text
+def process = ["sh", "-c", "tar cf $tarFile *"].execute([], tempLoadDir)
+assert process.waitFor() == 0, "Failed to package"
 
 // Set up the Artifactory information to publish the tar file
 def artifactoryURL = properties.get("artifactory.url") as String

--- a/PublishLoadModules/PublishLoadModule.groovy
+++ b/PublishLoadModules/PublishLoadModule.groovy
@@ -74,9 +74,7 @@ loadDatasetToMembersMap.each { dataset, members ->
 def buildGroup = "${properties.collection}" as String
 def buildLabel = "build.${properties.startTime}" as String
 def tarFile = new File("$tempLoadDir/${buildLabel}.tar")
-def process = "tar -cvf $tarFile .".execute(null, tempLoadDir)
-int rc = process.waitFor()
-assert rc == 0, "Failed to package load modules" 
+def tarOut = ["sh", "-c", "cd $tempLoadDir && tar cf $tarFile *"].execute().text
 
 //Set up the artifactory information to publish the tar file
 def artifactoryURL = properties.get("artifactory.url") as String

--- a/PublishLoadModules/PublishLoadModule.groovy
+++ b/PublishLoadModules/PublishLoadModule.groovy
@@ -9,8 +9,8 @@ import com.ibm.dbb.build.report.records.DefaultRecordFactory
 import groovyx.net.http.RESTClient
 
 /************************************************************************************
- * This script publishes the outputs generated from a build to an artifactory
- * repository. 
+ * This script publishes the outputs generated from a build to an Artifactory
+ * repository.
  *
  ************************************************************************************/
 
@@ -79,18 +79,14 @@ int rc = process.waitFor()
 assert rc == 0, "Failed to package load modules" 
 
 //Set up the artifactory information to publish the tar file
-def url = properties.get('artifactory.url')
-def apiKey = properties.get('artifactory.apiKey')
-def repo = properties.get('artifactory.repo') as String
+def artifactoryURL = properties.get("artifactory.url") as String
+def artifactoryRepo = properties.get("artifactory.repo") as String
+def artifactoryKey = properties.get("artifactory.apiKey") as String
 def remotePath = "${buildGroup}/${tarFile.name}"
 
 //Call the ArtifactoryHelpers to publish the tar file
 File artifactoryHelpersFile = new File('./ArtifactoryHelpers.groovy')
 Class artifactoryHelpersClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(artifactoryHelpersFile)
 GroovyObject artifactoryHelpers = (GroovyObject) artifactoryHelpersClass.newInstance()
-artifactoryHelpers.publish(url, repo, apiKey, remotePath, tarFile)
-
-
-
-
+artifactoryHelpers.publish(artifactoryURL, artifactoryRepo, artifactoryKey, remotePath, tarFile)
 

--- a/PublishLoadModules/PublishLoadModule.groovy
+++ b/PublishLoadModules/PublishLoadModule.groovy
@@ -126,5 +126,5 @@ def artifactoryComponent = properties.get("collection") as String
 File artifactoryHelpersFile = new File("$scriptDir/ArtifactoryHelpers.groovy")
 Class artifactoryHelpersClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(artifactoryHelpersFile)
 GroovyObject artifactoryHelpers = (GroovyObject) artifactoryHelpersClass.newInstance()
-artifactoryHelpers.publish(artifactoryURL, artifactoryRepo, artifactoryKey, "$artifactoryComponent/$tarFile.name", tarFile)
+def artifactoryPullableURL = artifactoryHelpers.publish(artifactoryURL, artifactoryRepo, artifactoryKey, "$artifactoryComponent/$tarFile.name", tarFile)
 

--- a/PublishLoadModules/PublishLoadModule.groovy
+++ b/PublishLoadModules/PublishLoadModule.groovy
@@ -104,26 +104,26 @@ new File(workDir).eachFileMatch(~/.*\.log/) { logFile ->
     copiedLogFile << logFile.text
 }
 
+// Get date for version label
 def date = new Date()
 def sdf = new SimpleDateFormat("yyyyMMdd-HHmmss")
 def startTime = sdf.format(date) as String
 
 // Package the load files just copied into a tar file using the build
-// label as the name for the tar file.
-def buildGroup = "${properties.collection}" as String
-def buildLabel = "build.$startTime" as String
+// label as the name for the tar file
+def buildLabel = "build.$startTime"
 def tarFile = new File("$tempLoadDir/${buildLabel}.tar")
 def tarOut = ["sh", "-c", "cd $tempLoadDir && tar cf $tarFile *"].execute().text
 
-// Set up the artifactory information to publish the tar file
+// Set up the Artifactory information to publish the tar file
 def artifactoryURL = properties.get("artifactory.url") as String
 def artifactoryRepo = properties.get("artifactory.repo") as String
 def artifactoryKey = properties.get("artifactory.apiKey") as String
-def remotePath = "${buildGroup}/${tarFile.name}"
+def artifactoryComponent = properties.get("collection") as String
 
 // Call the ArtifactoryHelpers to publish the tar file
 File artifactoryHelpersFile = new File("$scriptDir/ArtifactoryHelpers.groovy")
 Class artifactoryHelpersClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(artifactoryHelpersFile)
 GroovyObject artifactoryHelpers = (GroovyObject) artifactoryHelpersClass.newInstance()
-artifactoryHelpers.publish(artifactoryURL, artifactoryRepo, artifactoryKey, remotePath, tarFile)
+artifactoryHelpers.publish(artifactoryURL, artifactoryRepo, artifactoryKey, "$artifactoryComponent/$tarFile.name", tarFile)
 

--- a/PublishLoadModules/PublishLoadModule.groovy
+++ b/PublishLoadModules/PublishLoadModule.groovy
@@ -96,6 +96,13 @@ datasetsCSV.withWriter("UTF-8") { writer ->
 // Append build report
 def exportBuildReport = new File("$tempLoadDir/BuildReport.json")
 exportBuildReport << buildReportFile.text
+// Append all log files
+def logDirectory = new File("$tempLoadDir/Logs")
+logDirectory.mkdirs()
+new File(workDir).eachFileMatch(~/.*\.log/) { logFile ->
+    copiedLogFile = new File("$logDirectory/$logFile.name")
+    copiedLogFile << logFile.text
+}
 
 def date = new Date()
 def sdf = new SimpleDateFormat("yyyyMMdd-HHmmss")

--- a/PublishLoadModules/PublishLoadModule.groovy
+++ b/PublishLoadModules/PublishLoadModule.groovy
@@ -71,20 +71,26 @@ def copy = new CopyToHFS()
 def copyModeMap = ["COPYBOOK": CopyMode.TEXT, "DBRM": CopyMode.BINARY, "LOAD": CopyMode.LOAD]
 println "Number of load modules to publish: $loadCount"
 
+// Create a file to specify datasets
+def datasetsCSV = new File("$tempLoadDir/Datasets.csv")
+
 // Create dedicated directories for datasets (e.g. load modules and DBRMs)
-loadDatasetToMembersMap.each { dataset, members ->
-    datasetDir = new File("$tempLoadDir/$dataset")
-    datasetDir.mkdirs()
+datasetsCSV.withWriter("UTF-8") { writer ->
+    loadDatasetToMembersMap.each { dataset, members ->
+        datasetDir = new File("$tempLoadDir/$dataset")
+        datasetDir.mkdirs()
 
-    currentCopyMode = copyModeMap[dataset.replaceAll(/.*\.([^.]*)/, "\$1")]
-    copy.setCopyMode(currentCopyMode)
-    copy.setDataset(dataset)
+        currentCopyMode = copyModeMap[dataset.replaceAll(/.*\.([^.]*)/, "\$1")]
+        copy.setCopyMode(currentCopyMode)
+        copy.setDataset(dataset)
 
-    members.each { member ->
-        println "Copying $dataset($member) to $datasetDir"
-        copy.member(member).file(new File("$datasetDir/$member")).copy()
+        members.each { member ->
+            println "Copying $dataset($member) to $datasetDir"
+            copy.member(member).file(new File("$datasetDir/$member")).copy()
+        }
+
+        writer.writeLine dataset
     }
-
 }
 
 // Append build report

--- a/PublishLoadModules/PublishLoadModule.groovy
+++ b/PublishLoadModules/PublishLoadModule.groovy
@@ -60,12 +60,16 @@ tempLoadDir.mkdirs()
 //SSI and 
 CopyToHFS copy = new CopyToHFS().copyMode(CopyMode.LOAD)
 println "Number of load modules to publish: $loadCount"
+
+// Create dedicated directories for datasets (e.g. load modules and DBRMs)
 loadDatasetToMembersMap.each { dataset, members ->
+    datasetDir = new File("$tempLoadDir/$dataset")
+    datasetDir.mkdirs()
     members.each { member ->
         def fullyQualifiedDsn = "$dataset($member)"
-        def file = new File(tempLoadDir, member)
+        def file = new File(datasetDir, member)
         copy.dataset(dataset).member(member).file(file).copy()
-        println "Copying $dataset($member) to $tempLoadDir"
+        println "Copying $dataset($member) to $datasetDir"
     }
 }
 

--- a/PublishLoadModules/README.md
+++ b/PublishLoadModules/README.md
@@ -2,10 +2,10 @@
 This sample shows how to publish load modules to an artifactory repository after a successful build, as well as download load modules from the artifactory repository and restore them into an existing data set.  Since all of interaction with artifactory repository requires files on zFS, load modules need to copy from data set to files on zFS and vice-versa.  This sample therefore also makes use of the new options introduced in CopyToPDS and CopyToHFS APIs to copy between data set and files on zFS.
 
 ## Prerequisites:
-This sample is built on top of the Mortgage Application Sample, so it requires a successful Mortgage setup.  It also requires a set of jar files which can be downloaded from Maven Central Repository.  These jar files are required for making REST service calls to Artifactory Repository using Groovy, see ArtifactoryHelpers.groovy for more details. 
+This sample is built on top of the General-Insurance Application Sample, so it requires a successful General-Insurance setup.  It also requires a set of jar files which can be downloaded from Maven Central Repository.  These jar files are required for making REST service calls to Artifactory Repository using Groovy, see ArtifactoryHelpers.groovy for more details. 
 
 ## Scenario 1 - Publishing load modules from a successful build
-1. After a successful Mortgage build, it retrieves all outputs from the build report.
+1. After a successful General-Insurance build, it retrieves all outputs from the build report.
 2. From the list of the outputs, it filters the load modules based on the data sets specified in the build property 'loadDatasets'. For example: the build report could contain outputs from BMS, for example: USER1.DBB.COPYBOOKS(ESPMLIS), USER1.DBB.DBRM(EPSCMORT), USER1.DBB.LOAD(EPSCMORT), but the user is only interested in publishing load modules in USER1.DBB.LOAD. The build property 'loadDatasets' should then be set to  'USER1.DBB.LOAD' 
 3. It then invokes CopyToHFS to copy the load modules from the PDSe to a temporary directory on zFS.
 4. It packages these load files into a tar file, and compute the SHA1 and MD5 checksums.


### PR DESCRIPTION
All of this applies to the PublishLoadModules subdirectory

- Improved code style
- Fixed bugs like
  - builds would occasionally get rejected due to a checksum mismatch which occurred when the checksum had a leading zero
  - build tar file would include an empty version of itself
  - DBRMs loaded into the tempLoadDir would overwrite existing load modules with the same name
- Adjusted setup to the General-Insurance application rather than Mortgage